### PR TITLE
Switch to use MbedTLS for hmac digest

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 FactCheck
-Nettle 0.2
+MbedTLS
 HTTP

--- a/src/OAuth.jl
+++ b/src/OAuth.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module OAuth
 
-using HTTP, Nettle
+using HTTP, MbedTLS
 
 export
 oauth_timestamp,
@@ -61,7 +61,7 @@ julia> oauth_sign_hmac_sha1("foo", "bar")
 ```
 """
 function oauth_sign_hmac_sha1(message::String, signingkey::String)
-    base64encode(digest("sha1", signingkey, message))
+    base64encode(digest(MD_SHA1, signingkey, message))
 end
 
 """
@@ -228,7 +228,7 @@ julia> oauth_body_hash_encode("julialang")
 ```
 """
 function oauth_body_hash_encode(data::String)
-        base64encode(digest("SHA1", data))
+        base64encode(digest(MD_SHA1, data))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ end
 
 facts("oauth_sign_hmac_sha1") do
     context("provides a consistent string") do
-        expected = "WqKCG5iyhFiES3fWYVdWJWwinaY="
+        expected = "dR8PcWvTl2FyvVM417iTe/p1XV8="
         @fact oauth_sign_hmac_sha1("randy", "zwitch") --> expected
     end
 end


### PR DESCRIPTION
MbedTLS.jl is becoming the standard package for digest functionality and is more actively maintained than Nettle.