### PR TITLE
Update MbedTLS version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 HTTP = "~0.8.0"
 julia = "1.0"
-MbedTLS = "~1.0.0"
+MbedTLS = "0.6.0, 0.7.0, 1.0.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 HTTP = "~0.8.0"
 julia = "1.0"
-MbedTLS = "~0.6.0"
+MbedTLS = "~1.0.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Thanks for creating this repository, it was surprisingly simple to get 200 OK for the first step in some authentication flow :D (That's how far I got for now.)

Unfortunately, [MbedTLS.jl](https://github.com/JuliaLang/MbedTLS.jl) in this repository is severely outdated and forces [Genie.jl](https://github.com/GenieFramework/Genie.jl) back from `v1.1.0` to `v0.31.5`. With this pull request, I propose to update MbedTLS.