### PR TITLE
fix(ci): warm up the HTTP client before timed loopback tests

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -410,11 +410,14 @@ end
 
 function take_with_timeout(channel::Channel, timeout::Real)
     deadline = time() + timeout
-    while time() <= deadline
-        if isready(channel)
-            return take!(channel)
-        end
+    while true
+        isready(channel) && return take!(channel)
+        time() > deadline && break
         sleep(0.05)
     end
+    # The redirect may have landed while this task was descheduled - for example
+    # while another task held the thread - so check once more before giving up
+    # rather than discarding an authorization code we actually received.
+    isready(channel) && return take!(channel)
     throw(OAuthError(:timeout, "Timed out waiting for authorization redirect"))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1431,6 +1431,28 @@ function dispatch_loopback_callback(url::AbstractString; attempts::Integer=60, d
     error("Failed to send loopback callback request after $(attempts) attempts: $(last_error)")
 end
 
+# The first real HTTP.get in a process must compile HTTP.jl's entire request
+# pipeline. Under the flags julia-actions/julia-runtest uses (--check-bounds=yes,
+# which invalidates precompiled native code) that takes ~16s, which is longer than
+# the callback timeouts below allow - so the loopback tests timed out on CI while
+# passing locally. Warm the client stack once, outside any timed section.
+function warmup_http_client()
+    port = free_port()
+    router = HTTP.Router()
+    HTTP.register!(router, "GET", "/warmup", _ -> HTTP.Response(200, "ok"))
+    server = HTTP.serve!(router, DEFAULT_LOOPBACK_HOST, port)
+    try
+        HTTP.get("http://$(DEFAULT_LOOPBACK_HOST):$(port)/warmup"; status_exception=false, retry=false)
+    catch err
+        @warn "HTTP client warmup failed; loopback tests may be slow to start" err
+    finally
+        close(server)
+    end
+    return nothing
+end
+
+warmup_http_client()
+
 @testset "Loopback listener flow" begin
     prm_doc = Dict("authorization_servers" => ["https://id.example.org"])
     oas_doc = Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1892,3 +1892,19 @@ end
     @test issuer_call[1] == "https://id.register/register"
     @test HTTP.header(issuer_call[2], "Authorization") == "Bearer issuer-token"
 end
+
+@testset "take_with_timeout does not discard a late redirect" begin
+    # A redirect that lands while this task is descheduled (e.g. another task held
+    # the thread) must still be returned rather than reported as a timeout.
+    channel = Channel{OAuth.StringParams}(1)
+    params = OAuth.StringParams("code" => "abc", "state" => "s")
+    put!(channel, params)
+    @test OAuth.take_with_timeout(channel, 0) == params
+
+    empty_channel = Channel{OAuth.StringParams}(1)
+    @test_throws OAuthError OAuth.take_with_timeout(empty_channel, 0)
+
+    delivered = Channel{OAuth.StringParams}(1)
+    @async (sleep(0.2); put!(delivered, params))
+    @test OAuth.take_with_timeout(delivered, 5) == params
+end


### PR DESCRIPTION
`main` is currently red on its own: the `Loopback listener flow` test times out on **8 of 9** matrix jobs. This fixes it, and fixes a related robustness bug it exposed in the client.

## Root cause

The diagnostic was decisive: the listener starts correctly (`isopen=true`, port bound), but the callback task never completes a single loop iteration inside the 12s window — no attempt succeeds, and none even fails. That rules out networking, routing, and port binding.

The first real `HTTP.get` in the test process has to JIT the entire HTTP.jl request pipeline. Every preceding test uses mock HTTP objects, so the loopback test pays that cost — inside the timeout. Measured locally in a cold process:

| Julia flags | First `HTTP.get` | Second |
|---|---|---|
| default | 0.07s | 0.001s |
| `--check-bounds=yes --code-coverage=user` (what `julia-actions/julia-runtest` passes) | **15.99s** | 0.001s |

`--check-bounds=yes` invalidates precompiled native code, so everything is recompiled at runtime. And since `@async` shares the thread, that CPU-bound compile also starves the `take_with_timeout` poll loop — which is why the testset burns ~21s of wall time against a 12s deadline.

This matches the history: 4f1d2b1 ("fix(ci): stabilize loopback tests") raised the timeout 5s → 12s and held until the move to HTTP 2.x in f1b442d grew the compile stack past 12s. CI has not run on `main` since then (only CompatHelper), so it went unnoticed.

## Fixes

1. **`test/runtests.jl`** — warm the HTTP client stack once, outside any timed section, instead of inflating timeouts to paper over compile latency.
2. **`src/util.jl`** — `take_with_timeout` threw the instant the deadline passed, with no final `isready` check, so a redirect delivered while the task was descheduled was discarded as a timeout even though the authorization code had arrived. It now re-checks before giving up. This is a real client-side bug: on a loaded machine a CLI user could lose a valid callback. Covered by a new regression test.

## Verification

- CI on this branch: **10/10 jobs green** ([run 30425685906](https://github.com/JuliaServices/OAuth.jl/actions/runs/30425685906)).
- CI on unmodified `main`, same flags, same runners: **8/9 jobs fail** ([run 30425063122](https://github.com/JuliaServices/OAuth.jl/actions/runs/30425063122)).
- Full suite green locally on Julia 1.10 and 1.11, with and without coverage.

Found while reviewing #37; kept separate since it is unrelated to that PR's security work. Merging this first should turn #37 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)