### PR TITLE
fix(ci): allow slow Windows trim environment setup

### DIFF
--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -3,6 +3,7 @@ using Test
 const _TRIM_SAFE_ERROR_BUDGET = 0
 const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
 const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
+const _TRIM_SETUP_TIMEOUT_S = Sys.iswindows() ? 600.0 : 120.0
 const _TRIM_COMPILE_TIMEOUT_S = Sys.iswindows() ? 600.0 : 120.0
 const _TRIM_EXECUTABLE_TIMEOUT_S = Sys.iswindows() ? 120.0 : 30.0
 const _TRIM_USE_BUNDLE = Sys.iswindows()
@@ -30,7 +31,7 @@ function _setup_trim_env()
     flush(stdout)
     exit_code, output, timed_out = _run_command_with_timeout(
         _clean_cmd(`$julia --startup-file=no --history-file=no --project=$env_path $setup_script`);
-        timeout_s = 120.0,
+        timeout_s = _TRIM_SETUP_TIMEOUT_S,
         log_label = "setup",
     )
     rm(setup_script; force = true)


### PR DESCRIPTION
## Summary

- allow up to 10 minutes for JuliaC trim-environment setup on Windows
- retain the existing 2-minute setup limit on other platforms
- match the existing Windows-specific trim compile budget

## Why

The final `main` CI run after merging the 3.0 changes passed the package and loopback tests on Windows, but JuliaC environment setup was highly variable: one attempt took about 114 seconds and a retry exceeded the hard 120-second cap. This keeps the test bounded while avoiding a platform-specific setup flake.

## Testing

- Julia 1.12.6: full `Pkg.test()` passed, including the JuliaC trim workload (7/7 assertions)

Co-authored by Codex