### PR TITLE
Drop the Base64 stdlib and generate keys through libcrypto

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OAuth"
 uuid = "22d8b318-f366-56fb-a292-a93f7d76c017"
-version = "4.2.0"
+version = "4.3.0"
 
 [deps]
 AbstractStores = "b8592f88-5fd7-4e10-8c52-04e8e19aea3c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "4.2.0"
 
 [deps]
 AbstractStores = "b8592f88-5fd7-4e10-8c52-04e8e19aea3c"
-Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -25,7 +24,8 @@ SHA = "0.7"
 julia = "1.10"
 
 [extras]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Base64", "Test"]

--- a/src/OAuth.jl
+++ b/src/OAuth.jl
@@ -1,7 +1,7 @@
 module OAuth
 
 using AbstractStores
-using Dates, HTTP, JSON, JWTs, Random, SHA, Base64, OpenSSL_jll, FileWatching
+using Dates, HTTP, JSON, JWTs, Random, SHA, OpenSSL_jll, FileWatching
 
 const DEFAULT_RESPONSE_TYPE = "code"
 const MAX_DPOP_NONCE_RETRIES = 1

--- a/src/flow/common.jl
+++ b/src/flow/common.jl
@@ -246,7 +246,7 @@ function apply_token_endpoint_auth!(
             set!(form, "client_secret", credential.secret)
         elseif credential.method == :client_secret_basic
             credentials = string(form_escape(client_id), ":", form_escape(credential.secret))
-            encoded = Base64.base64encode(credentials)
+            encoded = base64standard(credentials)
             push!(headers, "Authorization" => "Basic $(encoded)")
         else
             throw(OAuthError(:configuration_error, "Unsupported client secret auth method $(credential.method)"))

--- a/src/jwt_util.jl
+++ b/src/jwt_util.jl
@@ -695,16 +695,23 @@ issuer = JWTAccessTokenIssuer(
 )
 ```
 
-# Note
-This function requires OpenSSL to be installed and available in your PATH.
 """
 function generate_rsa_private_key(; bits::Integer=2048)
     bits > 0 || error("RSA key size must be positive")
-    cmd = `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$bits`
+    ctx = ccall((:EVP_PKEY_CTX_new_id, LIBCRYPTO), Ptr{Cvoid}, (Cint, Ptr{Cvoid}), NID_RSA_ENCRYPTION, C_NULL)
+    JWTs.require_openssl_nonnull(ctx, "EVP_PKEY_CTX_new_id(RSA)")
     try
-        return read(cmd, String)
-    catch e
-        error("Failed to generate RSA key: $(e)")
+        JWTs.require_openssl_ok(
+            ccall((:EVP_PKEY_keygen_init, LIBCRYPTO), Cint, (Ptr{Cvoid},), ctx),
+            "EVP_PKEY_keygen_init",
+        )
+        JWTs.require_openssl_ok(
+            ccall((:EVP_PKEY_CTX_set_rsa_keygen_bits, LIBCRYPTO), Cint, (Ptr{Cvoid}, Cint), ctx, Cint(bits)),
+            "EVP_PKEY_CTX_set_rsa_keygen_bits",
+        )
+        return keygen_pem(ctx)
+    finally
+        ccall((:EVP_PKEY_CTX_free, LIBCRYPTO), Cvoid, (Ptr{Cvoid},), ctx)
     end
 end
 
@@ -729,16 +736,55 @@ issuer = JWTAccessTokenIssuer(
 )
 ```
 
-# Note
-This function requires OpenSSL to be installed and available in your PATH.
 """
 function generate_ec_private_key(; curve::Symbol=:P256)
-    curve in (:P256, :P384) || error("Unsupported EC curve: $curve (supported: :P256, :P384)")
-    curve_name = curve == :P256 ? "prime256v1" : "secp384r1"
-    cmd = `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:$curve_name`
+    crv = jose_curve_name(curve)
+    ctx = ccall((:EVP_PKEY_CTX_new_id, LIBCRYPTO), Ptr{Cvoid}, (Cint, Ptr{Cvoid}), NID_X9_62_EC, C_NULL)
+    JWTs.require_openssl_nonnull(ctx, "EVP_PKEY_CTX_new_id(EC)")
     try
-        return read(cmd, String)
-    catch e
-        error("Failed to generate EC key: $(e)")
+        JWTs.require_openssl_ok(
+            ccall((:EVP_PKEY_keygen_init, LIBCRYPTO), Cint, (Ptr{Cvoid},), ctx),
+            "EVP_PKEY_keygen_init",
+        )
+        JWTs.require_openssl_ok(
+            ccall((:EVP_PKEY_CTX_set_ec_paramgen_curve_nid, LIBCRYPTO), Cint, (Ptr{Cvoid}, Cint), ctx, JWTs.ec_group_nid(crv)),
+            "EVP_PKEY_CTX_set_ec_paramgen_curve_nid",
+        )
+        return keygen_pem(ctx)
+    finally
+        ccall((:EVP_PKEY_CTX_free, LIBCRYPTO), Cvoid, (Ptr{Cvoid},), ctx)
+    end
+end
+
+# Finish a configured keygen context and PEM-encode the key (unencrypted
+# PKCS#8, the same form `openssl genpkey` emits).
+function keygen_pem(ctx::Ptr{Cvoid})
+    pkey_ref = Ref{Ptr{Cvoid}}(C_NULL)
+    JWTs.require_openssl_ok(
+        ccall((:EVP_PKEY_keygen, LIBCRYPTO), Cint, (Ptr{Cvoid}, Ref{Ptr{Cvoid}}), ctx, pkey_ref),
+        "EVP_PKEY_keygen",
+    )
+    pkey = pkey_ref[]
+    bio = Ptr{Cvoid}(C_NULL)
+    try
+        method = ccall((:BIO_s_mem, LIBCRYPTO), Ptr{Cvoid}, ())
+        bio = ccall((:BIO_new, LIBCRYPTO), Ptr{Cvoid}, (Ptr{Cvoid},), method)
+        JWTs.require_openssl_nonnull(bio, "BIO_new")
+        JWTs.require_openssl_ok(
+            ccall(
+                (:PEM_write_bio_PKCS8PrivateKey, LIBCRYPTO),
+                Cint,
+                (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Ptr{Cvoid}),
+                bio, pkey, C_NULL, C_NULL, Cint(0), C_NULL, C_NULL,
+            ),
+            "PEM_write_bio_PKCS8PrivateKey",
+        )
+        data_ref = Ref{Ptr{UInt8}}(C_NULL)
+        len = ccall((:BIO_ctrl, LIBCRYPTO), Clong, (Ptr{Cvoid}, Cint, Clong, Ref{Ptr{UInt8}}), bio, 3, 0, data_ref) # BIO_CTRL_INFO
+        (len > 0 && data_ref[] != C_NULL) || throw(JWTs.openssl_error("BIO_ctrl(BIO_CTRL_INFO)"))
+        return unsafe_string(data_ref[], len)
+    finally
+        JWTs.free_bio!(bio)
+        JWTs.free_evp_pkey!(pkey)
     end
 end

--- a/src/jwt_util.jl
+++ b/src/jwt_util.jl
@@ -106,7 +106,7 @@ function decode_pem(data::AbstractString)
     end
     encoded = String(take!(io))
     close(io)
-    return Base64.base64decode(encoded)
+    return base64urldecode(encoded)
 end
 
 normalize_key_bytes(data::AbstractString) = decode_pem(data)

--- a/src/server.jl
+++ b/src/server.jl
@@ -1651,7 +1651,7 @@ function client_credentials_authenticator(credentials; allow_public::Bool=false)
         if credentials !== nothing && ascii_lc_isequal(credentials.scheme, "basic")
             encoded = credentials.token
             decoded = try
-                String(Base64.base64decode(encoded))
+                String(base64urldecode(encoded))
             catch err
                 throw(OAuthError(:invalid_client, "Invalid Authorization header: $(err)"))
             end
@@ -2228,7 +2228,7 @@ function authenticate_request(auth::BasicCredentialsAuthenticator, req::HTTP.Req
     end
     encoded = credentials.token
     decoded = try
-        String(Base64.base64decode(encoded))
+        String(base64urldecode(encoded))
     catch
         return false
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -72,7 +72,7 @@ function refresh_token_file_contents(token::String)
     payload = Dict(
         "version" => TOKEN_FILE_VERSION,
         "encoding" => TOKEN_FILE_ENCODING,
-        "refresh_token" => Base64.base64encode(token),
+        "refresh_token" => base64standard(token),
     )
     return JSON.json(payload) * "\n"
 end
@@ -103,7 +103,7 @@ function decode_token_field(value, encoding::String)
     value isa AbstractString || return nothing
     if encoding == TOKEN_FILE_ENCODING
         decoded = try
-            Base64.base64decode(String(value))
+            base64urldecode(String(value))
         catch
             nothing
         end
@@ -941,8 +941,8 @@ function token_file_contents(token::TokenResponse)
     payload = Dict(
         "version" => TOKEN_FILE_VERSION,
         "encoding" => TOKEN_FILE_ENCODING,
-        "access_token" => Base64.base64encode(token.access_token),
-        "refresh_token" => token.refresh_token === nothing ? nothing : Base64.base64encode(token.refresh_token),
+        "access_token" => base64standard(token.access_token),
+        "refresh_token" => token.refresh_token === nothing ? nothing : base64standard(token.refresh_token),
         "expires_at" => token.expires_at === nothing ? nothing : string(token.expires_at),
         "token_type" => token.token_type,
         "scope" => token.scope,

--- a/src/util.jl
+++ b/src/util.jl
@@ -281,6 +281,59 @@ function base64url(bytes::AbstractVector{UInt8})
     return String(out)
 end
 
+const BASE64STD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+const BASE64STD_ENCODE_TABLE = Vector{UInt8}(codeunits(BASE64STD_CHARS))
+
+"""
+    base64standard(data) -> String
+
+Standard base64-encode `data` with `=` padding, per RFC 4648 Section 4 (the form
+HTTP Basic credentials and the token cache files use). Implemented directly for
+the same reason as [`base64url`](@ref): the Base64 stdlib's IO-pipe
+implementation is not resolvable under `juliac --trim=safe`. Decoding needs no
+standard-alphabet twin — [`base64urldecode`](@ref) accepts both alphabets and
+padding.
+"""
+function base64standard(bytes::AbstractVector{UInt8})
+    n = length(bytes)
+    n == 0 && return ""
+    out = Vector{UInt8}(undef, 4 * cld(n, 3))
+    table = BASE64STD_ENCODE_TABLE
+    j = 0
+    i = firstindex(bytes)
+    last = lastindex(bytes)
+    @inbounds while i + 2 <= last
+        b1 = bytes[i]
+        b2 = bytes[i + 1]
+        b3 = bytes[i + 2]
+        out[j + 1] = table[Int(b1 >> 2) + 1]
+        out[j + 2] = table[Int(((b1 & 0x03) << 4) | (b2 >> 4)) + 1]
+        out[j + 3] = table[Int(((b2 & 0x0f) << 2) | (b3 >> 6)) + 1]
+        out[j + 4] = table[Int(b3 & 0x3f) + 1]
+        j += 4
+        i += 3
+    end
+    @inbounds if i + 1 <= last
+        b1 = bytes[i]
+        b2 = bytes[i + 1]
+        out[j + 1] = table[Int(b1 >> 2) + 1]
+        out[j + 2] = table[Int(((b1 & 0x03) << 4) | (b2 >> 4)) + 1]
+        out[j + 3] = table[Int((b2 & 0x0f) << 2) + 1]
+        out[j + 4] = UInt8('=')
+        j += 4
+    elseif i <= last
+        b1 = bytes[i]
+        out[j + 1] = table[Int(b1 >> 2) + 1]
+        out[j + 2] = table[Int((b1 & 0x03) << 4) + 1]
+        out[j + 3] = UInt8('=')
+        out[j + 4] = UInt8('=')
+        j += 4
+    end
+    resize!(out, j)
+    return String(out)
+end
+base64standard(data::AbstractString) = base64standard(codeunits(String(data)))
+
 """
     base64urldecode(str) -> Vector{UInt8}
 


### PR DESCRIPTION
Rebases the two follow-up commits from #44 onto main, plus a version bump to 4.3.0:

1. **Drop the Base64 stdlib dependency.** OAuth's hand-rolled trim-clean base64url codec gains a standard-alphabet encoder (`base64standard`, RFC 4648 §4 with padding, fuzz-checked byte-identical to `Base64.base64encode` over 20k random vectors); PEM decoding, HTTP Basic client-secret encoding, and the token-cache files route through it. Existing token files stay readable (`base64urldecode` accepts both alphabets and padding) and written formats are byte-identical. Base64 stays as a test-only oracle.

2. **Generate keys through libcrypto instead of the `openssl` binary.** `generate_rsa_private_key`/`generate_ec_private_key` used to shell out, requiring the binary on PATH and pulling Base's process-spawn machinery into statically compiled consumers (~39 verify errors in a `juliac --trim=safe` server traced into that one call). Classic EVP keygen with `PEM_write_bio_PKCS8PrivateKey` emits the same unencrypted PKCS#8 PEM; the `openssl` binary cross-validates the output in the smoke check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)