### PR TITLE
Let the token store carry an application-declared claims type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ JWTs = "d850fbd6-035d-5a70-a269-1ca2e636ac6c"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+StructUtils = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
@@ -21,6 +22,7 @@ JSON = "1"
 JWTs = "1.1"
 OpenSSL_jll = "3"
 SHA = "0.7"
+StructUtils = "2"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OAuth"
 uuid = "22d8b318-f366-56fb-a292-a93f7d76c017"
-version = "4.3.0"
+version = "4.4.0"
 
 [deps]
 AbstractStores = "b8592f88-5fd7-4e10-8c52-04e8e19aea3c"

--- a/README.md
+++ b/README.md
@@ -415,6 +415,27 @@ directly to their convenience constructors. The older
 `authorization_server_stores(backend)` helper remains available and returns the
 same three stores as a named tuple.
 
+Access-token claims use `Dict{String,Any}` by default. A trim-compiled service,
+or a service that wants typed JSON persistence, can declare its exact claim
+shape. Field names match JWT claim names. Optional fields include `Nothing`;
+unknown claims are dropped.
+
+```julia
+Base.@kwdef struct AccessClaims
+    iss::Union{Nothing,String} = nothing
+    sub::Union{Nothing,String} = nothing
+    aud::Union{Nothing,String,Vector{String}} = nothing
+    exp::Union{Nothing,Int64} = nothing
+    iat::Union{Nothing,Int64} = nothing
+    jti::Union{Nothing,String} = nothing
+    client_id::Union{Nothing,String} = nothing
+    scope::Union{Nothing,String} = nothing
+    tenant::Union{Nothing,String} = nothing
+end
+
+stores = OAuth.AuthorizationServerStores(MemoryStore(); claims=AccessClaims)
+```
+
 `AuthorizationEndpointConfig` and `TokenEndpointConfig` require an atomic,
 TTL-capable authorization-code store, because RFC 6749 §4.1.2 requires a code to
 be redeemable exactly once. `MemoryStore`, `SQLStore`, and `RedisStore` provide
@@ -429,7 +450,10 @@ With such a codec, give each kind of state its own concretely typed store:
 
 ```julia
 stores = OAuth.AuthorizationServerStores(
-    access_tokens=FileStore{OAuth.AccessTokenRecord}(access_dir; codec=JSONCodec()),
+    access_tokens=FileStore{OAuth.AccessTokenRecord{AccessClaims}}(
+        access_dir;
+        codec=JSONCodec(),
+    ),
     authorization_codes=FileStore{OAuth.AuthorizationCodeRecord}(code_dir; codec=JSONCodec()),
     refresh_grants=FileStore{OAuth.RefreshTokenGrantRecord}(refresh_dir; codec=JSONCodec()),
 )

--- a/src/OAuth.jl
+++ b/src/OAuth.jl
@@ -1,7 +1,7 @@
 module OAuth
 
 using AbstractStores
-using Dates, HTTP, JSON, JWTs, Random, SHA, OpenSSL_jll, FileWatching
+using Dates, HTTP, JSON, JWTs, Random, SHA, OpenSSL_jll, FileWatching, StructUtils
 
 const DEFAULT_RESPONSE_TYPE = "code"
 const MAX_DPOP_NONCE_RETRIES = 1
@@ -46,7 +46,7 @@ export stop_loopback_listener
 export DEFAULT_LOOPBACK_HOST, DEFAULT_LOOPBACK_PORT, DEFAULT_LOOPBACK_PATH
 export ProtectedResourceConfig, AuthorizationServerConfig, JWTAccessTokenIssuer, IssuedAccessToken
 export AccessTokenClaims, TokenValidationConfig, DPoPReplayCache, DeviceAuthorizationResponse
-export AccessTokenStore, AccessTokenRecord, InMemoryTokenStore
+export AccessTokenStore, AccessTokenRecord, InMemoryTokenStore, claimstype
 export AllowAllAuthenticator, BasicCredentialsAuthenticator
 export register_protected_resource_metadata!, register_authorization_server_metadata!
 export register_jwks_endpoint!, protected_resource_middleware, public_jwk, DEFAULT_JWKS_PATH

--- a/src/server.jl
+++ b/src/server.jl
@@ -453,16 +453,46 @@ end
 
 Stored representation of an issued access token.
 """
-struct AccessTokenRecord
+struct AccessTokenRecord{C}
     token::String
     scope::Vector{String}
     issued_at::DateTime
     expires_at::DateTime
     client_id::Union{String,Nothing}
     subject::Union{String,Nothing}
-    claims::Dict{String,Any}
+    claims::C
     revoked::Bool
     confirmation_jkt::Union{String,Nothing}
+end
+
+# Default: the claims persist as they were issued, an open `Dict{String,Any}`.
+AccessTokenRecord(token, scope, issued_at, expires_at, client_id, subject, claims::Dict{String,Any}, revoked, confirmation_jkt) =
+    AccessTokenRecord{Dict{String,Any}}(token, scope, issued_at, expires_at, client_id, subject, claims, revoked, confirmation_jkt)
+
+"""
+    OAuth.claimstype(store::AccessTokenStore) -> Type
+
+The claims type `C` of the `AccessTokenRecord{C}` values a token store holds.
+`Dict{String,Any}` by default; a custom claims struct when the store was built
+with `AuthorizationServerStores(backend; claims=MyClaims)` or typed directly as
+`AbstractStore{AccessTokenRecord{MyClaims}}`.
+"""
+claimstype(::AbstractStore{AccessTokenRecord{C}}) where {C} = C
+claimstype(::AbstractStore{AccessTokenRecord}) = Dict{String,Any}
+
+# Convert an issued claim set into the store's claims type. The default keeps
+# the dict as is; a custom struct is built with StructUtils' typed
+# construction, so a JSON-backed store round-trips it through typed reads and
+# writes — the shape a statically compiled (`juliac --trim`) server needs.
+storedclaims(::Type{Dict{String,Any}}, claims::Dict{String,Any}) = claims
+storedclaims(::Type{C}, claims::Dict{String,Any}) where {C} = StructUtils.make(C, claims)
+
+# Read one claim from a stored claims value: a dict lookup, or a field of a
+# custom claims struct (`nothing` when the struct has no such field).
+claimget(claims::AbstractDict, name::String) = get(claims, name, nothing)
+function claimget(claims::T, name::String) where {T}
+    sym = Symbol(name)
+    return hasfield(T, sym) ? getfield(claims, sym) : nothing
 end
 
 """
@@ -480,7 +510,7 @@ Expired records are never returned, but a store that does not expire entries
 natively — `MemoryStore`, `FileStore` — only reclaims one when it is read. Call
 `AbstractStores.sweep!` periodically on a long-lived store.
 """
-const AccessTokenStore = AbstractStore{AccessTokenRecord}
+const AccessTokenStore = AbstractStore{<:AccessTokenRecord}
 
 """
     InMemoryTokenStore()
@@ -711,14 +741,15 @@ filesystem filename limits.
 """
 function store_access_token!(store::AccessTokenStore, issued::IssuedAccessToken;
                              now::DateTime=Dates.now(UTC))
-    record = AccessTokenRecord(
+    C = claimstype(store)
+    record = AccessTokenRecord{C}(
         issued.token,
         copy(issued.scope),
         issued.issued_at,
         issued.expires_at,
         issued.client_id,
         issued.subject,
-        Dict{String,Any}(issued.claims),
+        storedclaims(C, Dict{String,Any}(issued.claims)),
         false,
         issued.confirmation_jkt,
     )
@@ -1029,15 +1060,15 @@ return stored values without changing their types. Use the keyword constructor
 with three independently typed stores when the backend codec cannot provide
 that guarantee.
 """
-function AuthorizationServerStores(backend::AbstractStore)
-    for T in (AccessTokenRecord, AuthorizationCodeRecord, RefreshTokenGrantRecord)
+function AuthorizationServerStores(backend::AbstractStore; claims::Type=Dict{String,Any})
+    for T in (AccessTokenRecord{claims}, AuthorizationCodeRecord, RefreshTokenGrantRecord)
         eltype(backend) >: T || throw(ArgumentError(
             "AuthorizationServerStores needs a backend whose eltype can hold $T; " *
             "got $(typeof(backend)) with eltype $(eltype(backend)). Pass a store " *
             "parameterized on `Any`, or build one typed store per record type."))
     end
     return AuthorizationServerStores(
-        PrefixedStore{AccessTokenRecord}(backend, "oauth/access/"),
+        PrefixedStore{AccessTokenRecord{claims}}(backend, "oauth/access/"),
         PrefixedStore{AuthorizationCodeRecord}(backend, "oauth/code/"),
         PrefixedStore{RefreshTokenGrantRecord}(backend, "oauth/refresh/"),
     )
@@ -1099,15 +1130,15 @@ The authorization-code store must additionally be atomic and TTL-capable — see
 compare-and-swap, so it is rejected for authorization codes; it remains fine for
 access-token state in a single service process.
 """
-function authorization_server_stores(backend::AbstractStore)
-    for T in (AccessTokenRecord, AuthorizationCodeRecord, RefreshTokenGrantRecord)
+function authorization_server_stores(backend::AbstractStore; claims::Type=Dict{String,Any})
+    for T in (AccessTokenRecord{claims}, AuthorizationCodeRecord, RefreshTokenGrantRecord)
         eltype(backend) >: T || throw(ArgumentError(
             "authorization_server_stores needs a backend whose eltype can hold $T; " *
             "got $(typeof(backend)) with eltype $(eltype(backend)). Pass a store " *
             "parameterized on `Any`, or build one typed store per record type."))
     end
     return (
-        access_tokens=PrefixedStore{AccessTokenRecord}(
+        access_tokens=PrefixedStore{AccessTokenRecord{claims}}(
             backend,
             "oauth/access/",
         ),
@@ -2831,9 +2862,10 @@ function build_introspection_handler(store::AccessTokenStore; authenticator::Uni
         if record === nothing || record.revoked || Dates.now(UTC) > record.expires_at
             return json_no_store_response(Dict("active" => false))
         end
+        claims = record.claims
         response = Dict{String,Any}(
             "active" => true,
-            "iss" => get(record.claims, "iss", nothing),
+            "iss" => claimget(claims, "iss"),
             "client_id" => record.client_id,
             "sub" => record.subject,
             "exp" => datetime_to_unix(record.expires_at),
@@ -2841,12 +2873,10 @@ function build_introspection_handler(store::AccessTokenStore; authenticator::Uni
             "scope" => join(record.scope, ' '),
             "token_type" => "access_token",
         )
-        haskey(record.claims, "aud") && (response["aud"] = record.claims["aud"])
-        haskey(record.claims, "nbf") && (response["nbf"] = record.claims["nbf"])
-        haskey(record.claims, "authorization_details") && (response["authorization_details"] = record.claims["authorization_details"])
-        haskey(record.claims, "auth_time") && (response["auth_time"] = record.claims["auth_time"])
-        haskey(record.claims, "azp") && (response["azp"] = record.claims["azp"])
-        haskey(record.claims, "username") && (response["username"] = record.claims["username"])
+        for name in ("aud", "nbf", "authorization_details", "auth_time", "azp", "username")
+            value = claimget(claims, name)
+            value === nothing || (response[name] = value)
+        end
         return json_no_store_response(response)
     end
     return handler

--- a/src/server.jl
+++ b/src/server.jl
@@ -409,10 +409,12 @@ Holds the signing material and metadata required to mint JWT access tokens
 for your resource server.  Combine with [`issue_access_token`](@ref) and
 [`public_jwk`](@ref) to build your own auth server in a few lines.
 """
-mutable struct JWTAccessTokenIssuer
+# Parametric on the signer so token minting dispatches statically (juliac
+# --trim); an abstract signer field would make every sign_jws call dynamic.
+mutable struct JWTAccessTokenIssuer{S<:JWTSigner}
     issuer::String
     audience::Vector{String}
-    signer::JWTSigner
+    signer::S
     alg::Symbol
     kid::Union{String,Nothing}
     expires_in::Int
@@ -440,7 +442,10 @@ function JWTAccessTokenIssuer(; issuer, audience, private_key, alg::Union{Symbol
     aud = normalize_string_vector(audience)
     kid_value = maybe_string(kid)
     jwk_dict = public_jwk === nothing ? derive_signing_jwk(private_key, signer, alg_symbol, kid_value) : normalize_metadata_dict(public_jwk)
-    return JWTAccessTokenIssuer(String(issuer), aud, signer, alg_symbol, kid_value, Int(expires_in), jwk_dict)
+    # explicit conversion: a parametric struct's implicit constructor does not
+    # convert field arguments (derive_signing_jwk may return Dict{String,String})
+    jwk_any = jwk_dict === nothing ? nothing : convert(Dict{String,Any}, jwk_dict)
+    return JWTAccessTokenIssuer(String(issuer), aud, signer, alg_symbol, kid_value, Int(expires_in), jwk_any)
 end
 
 """
@@ -1128,10 +1133,11 @@ service rotate within one stored token family so replaying an older generation
 revokes the active family.
 """
 struct TokenService{
+    I<:JWTAccessTokenIssuer,
     A<:AccessTokenStore,
     R<:RefreshTokenGrantStore,
 }
-    issuer::JWTAccessTokenIssuer
+    issuer::I
     access_tokens::A
     refresh_grants::R
     refresh_token_ttl::Union{Dates.Second,Nothing}
@@ -1500,9 +1506,9 @@ store, token issuer, client authenticator, refresh token generator, extra
 claims callback, optional persistent token store, allowed grant types, and an
 optional [`TokenService`](@ref) for family-aware refresh-token rotation.
 """
-struct TokenEndpointConfig{S<:AuthorizationCodeStore,C<:Function,R<:Function,E<:Function}
+struct TokenEndpointConfig{S<:AuthorizationCodeStore,I<:JWTAccessTokenIssuer,C<:Function,R<:Function,E<:Function}
     code_store::S
-    token_issuer::JWTAccessTokenIssuer
+    token_issuer::I
     client_authenticator::C
     refresh_token_generator::R
     extra_token_claims::E

--- a/src/server.jl
+++ b/src/server.jl
@@ -476,16 +476,34 @@ The claims type `C` of the `AccessTokenRecord{C}` values a token store holds.
 `Dict{String,Any}` by default; a custom claims struct when the store was built
 with `AuthorizationServerStores(backend; claims=MyClaims)` or typed directly as
 `AbstractStore{AccessTokenRecord{MyClaims}}`.
+
+A custom claims type must be a concrete struct whose field names match the JWT
+claim names it retains. Stored values must satisfy the declared field types.
+Unknown claims are dropped, and an absent claim supplies `nothing`, so optional
+fields should include `Nothing`. This exact shape keeps construction statically
+dispatchable under `juliac --trim`.
 """
 claimstype(::AbstractStore{AccessTokenRecord{C}}) where {C} = C
 claimstype(::AbstractStore{AccessTokenRecord}) = Dict{String,Any}
 
 # Convert an issued claim set into the store's claims type. The default keeps
-# the dict as is; a custom struct is built with StructUtils' typed
-# construction, so a JSON-backed store round-trips it through typed reads and
-# writes — the shape a statically compiled (`juliac --trim`) server needs.
+# the dict as is. For a custom struct, first project the heterogeneous dict to
+# statically typed field values, then call the struct's normal positional
+# constructor. This avoids dynamic field dispatch under `juliac --trim`; a
+# JSON-backed store can still round-trip the result through StructUtils' typed
+# reads and writes.
 storedclaims(::Type{Dict{String,Any}}, claims::Dict{String,Any}) = claims
-storedclaims(::Type{C}, claims::Dict{String,Any}) where {C} = StructUtils.make(C, claims)
+@generated function storedclaims(::Type{C}, claims::Dict{String,Any}) where {C}
+    C isa DataType && isconcretetype(C) && isstructtype(C) ||
+        return :(StructUtils.make(C, claims))
+    values = Any[]
+    for i in 1:fieldcount(C)
+        key = String(fieldname(C, i))
+        field_type = fieldtype(C, i)
+        push!(values, :(get(claims, $key, nothing)::$field_type))
+    end
+    return :($C($(values...)))
+end
 
 # Read one claim from a stored claims value: a dict lookup, or a field of a
 # custom claims struct (`nothing` when the struct has no such field).

--- a/test/oauth_trim_server.jl
+++ b/test/oauth_trim_server.jl
@@ -18,6 +18,18 @@ function _trim_claims()::Dict{String,Any}
     return claims
 end
 
+Base.@kwdef struct TrimClaims
+    iss::Union{Nothing,String} = nothing
+    sub::Union{Nothing,String} = nothing
+    aud::Union{Nothing,String,Vector{String}} = nothing
+    exp::Union{Nothing,Int64} = nothing
+    iat::Union{Nothing,Int64} = nothing
+    jti::Union{Nothing,String} = nothing
+    client_id::Union{Nothing,String} = nothing
+    scope::Union{Nothing,String} = nothing
+    tenant::Union{Nothing,String} = nothing
+end
+
 function _trim_token_store()::Nothing
     now = OAuth.Dates.DateTime(2026, 8, 9, 12, 0, 0)
     issued = OAuth.IssuedAccessToken(
@@ -39,6 +51,48 @@ function _trim_token_store()::Nothing
     _trim_server_assert(OAuth.revoke_access_token!(store, issued.token), "token revocation")
     _trim_server_assert(OAuth.lookup_access_token(store, issued.token) === nothing,
                         "revoked token lookup")
+    return nothing
+end
+
+function _trim_typed_claims_store()::Nothing
+    now = OAuth.Dates.DateTime(2026, 8, 9, 12, 0, 0)
+    stores = OAuth.AuthorizationServerStores(
+        OAuth.AbstractStores.MemoryStore();
+        claims=TrimClaims,
+    )
+    _trim_server_assert(
+        OAuth.claimstype(stores.access_tokens) === TrimClaims,
+        "typed claims store",
+    )
+    claims = _trim_claims()
+    claims["exp"] = OAuth.datetime_to_unix(now + OAuth.Dates.Minute(10))
+    claims["iat"] = OAuth.datetime_to_unix(now)
+    claims["jti"] = "trim-jti"
+    claims["client_id"] = "soleil"
+    claims["tenant"] = "acme"
+    issued = OAuth.IssuedAccessToken(
+        "trim-typed-access-token",
+        claims,
+        ["solar:read", "solar:write"],
+        now,
+        now + OAuth.Dates.Minute(10),
+        "soleil",
+        "user-42",
+        nothing,
+    )
+    OAuth.store_access_token!(stores.access_tokens, issued; now)
+    record = OAuth.lookup_access_token(stores.access_tokens, issued.token)
+    record isa OAuth.AccessTokenRecord{TrimClaims} || error("typed access token record")
+    claims = record.claims
+    _trim_server_assert(claims.tenant == "acme", "typed custom claim")
+    _trim_server_assert(claims.sub == "user-42", "typed subject claim")
+    _trim_server_assert(claims.aud == "https://api.example", "typed audience claim")
+    _trim_server_assert(
+        OAuth.claimget(claims, "iss") == "https://issuer.example",
+        "typed claim lookup",
+    )
+    _trim_server_assert(OAuth.claimget(claims, "unknown") === nothing,
+                        "unknown typed claim lookup")
     return nothing
 end
 
@@ -173,6 +227,7 @@ end
 function run_oauth_trim_server()::Nothing
     _trim_rsa_signing()
     _trim_token_store()
+    _trim_typed_claims_store()
     _trim_authorization_code_store()
     _trim_token_service()
     return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1636,6 +1636,19 @@ end
     @test doc["active"] == true
     @test doc["iss"] == "https://id.example.com"
     @test doc["sub"] == "user-9"
+    # A portable codec must decode the persisted record and nested claims at
+    # their declared types rather than falling back to Dict{String,Any}.
+    mktempdir() do directory
+        json_store = FileStore{AccessTokenRecord{AppClaims}}(
+            directory;
+            codec = JSONCodec(),
+        )
+        store_access_token!(json_store, issued; now = issued.issued_at)
+        json_record = lookup_access_token(json_store, issued.token)
+        @test json_record isa AccessTokenRecord{AppClaims}
+        @test json_record.claims isa AppClaims
+        @test json_record.claims.tenant == "acme"
+    end
     # the default path is unchanged: an untyped store keeps Dict{String,Any}
     default_store = InMemoryTokenStore()
     @test OAuth.claimstype(default_store) === Dict{String,Any}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1590,6 +1590,59 @@ end
     @test result2.discovery.authorization_server.issuer == "https://id.example.io"
 end
 
+# A claims struct declared by the application: the store then persists
+# AccessTokenRecord{AppClaims} and reads it back typed — no Dict{String,Any}
+# in the persisted record, which is what a juliac --trim server needs.
+Base.@kwdef struct AppClaims
+    iss::Union{Nothing,String} = nothing
+    sub::Union{Nothing,String} = nothing
+    aud::Union{Nothing,String,Vector{String}} = nothing
+    exp::Union{Nothing,Int64} = nothing
+    iat::Union{Nothing,Int64} = nothing
+    jti::Union{Nothing,String} = nothing
+    client_id::Union{Nothing,String} = nothing
+    scope::Union{Nothing,String} = nothing
+    tenant::Union{Nothing,String} = nothing   # a custom claim the app declares
+end
+
+@testset "custom claims struct in the token store" begin
+    rsa_pem = fixture_string("rsa_private.pem")
+    issuer = JWTAccessTokenIssuer(
+        issuer = "https://id.example.com",
+        audience = ["https://api.example.com"],
+        private_key = rsa_pem,
+    )
+    backend = AbstractStores.MemoryStore()
+    stores = OAuth.AuthorizationServerStores(backend; claims = AppClaims)
+    @test OAuth.claimstype(stores.access_tokens) === AppClaims
+    issued = issue_access_token(
+        issuer;
+        subject = "user-9",
+        client_id = "client-a",
+        scope = ["read"],
+        extra_claims = Dict{String,Any}("tenant" => "acme", "ignored_by_struct" => 1),
+        store = stores.access_tokens,
+    )
+    record = lookup_access_token(stores.access_tokens, issued.token)
+    @test record isa AccessTokenRecord{AppClaims}
+    @test record.claims.sub == "user-9"
+    @test record.claims.tenant == "acme"
+    @test record.claims.aud == ["https://api.example.com"] || record.claims.aud == "https://api.example.com"
+    @test record.claims.exp isa Int64
+    # introspection reads through the struct's fields
+    handler = build_introspection_handler(stores.access_tokens; authenticator = AllowAllAuthenticator())
+    resp = handler(HTTP.Request("POST", "/introspect", ["Content-Type" => "application/x-www-form-urlencoded"], "token=$(issued.token)"))
+    doc = JSON.parse(String(resp.body))
+    @test doc["active"] == true
+    @test doc["iss"] == "https://id.example.com"
+    @test doc["sub"] == "user-9"
+    # the default path is unchanged: an untyped store keeps Dict{String,Any}
+    default_store = InMemoryTokenStore()
+    @test OAuth.claimstype(default_store) === Dict{String,Any}
+    issued2 = issue_access_token(issuer; subject = "user-10", store = default_store)
+    @test lookup_access_token(default_store, issued2.token).claims isa Dict{String,Any}
+end
+
 @testset "Server helpers" begin
     prm_config = ProtectedResourceConfig(
         resource = "https://api.example.com",


### PR DESCRIPTION
`AccessTokenRecord` persisted claims as `Dict{String,Any}`. That stays the default, so dynamic servers do not change. A JSON-backed store decodes that shape through dynamic paths, which a statically compiled (`juliac --trim`) server cannot use. The claim shape therefore belongs to the application:

- `AccessTokenRecord{C}` carries claims as `C`, with `Dict{String,Any}` as the default.
- `AuthorizationServerStores(backend; claims=MyClaims)` and `authorization_server_stores(backend; claims=...)` type the access-token store.
- `store_access_token!` projects issued claims onto the declared fields, checks each value against its field type, and calls the concrete claims constructor. Unknown claims are dropped. Missing fields receive `nothing`.
- JSON-backed stores read and write `AccessTokenRecord{MyClaims}` at the declared type.
- Introspection reads either dictionaries or typed fields through `claimget`; `claimstype(store)` reports the configured type.

Trim users declare a concrete struct with the claims they issue. Optional fields include `Nothing`. The README now documents this pattern and the typed `JSONCodec` store form.

The server trim workload now exercises the real typed path: it creates `AuthorizationServerStores(...; claims=TrimClaims)`, stores an issued claim set with a custom `tenant` claim, reads back `AccessTokenRecord{TrimClaims}`, and performs typed claim lookup. Adding that workload initially exposed 13 verifier errors in the old `StructUtils.make(C, Dict{String,Any})` path. The static field projection removes them while retaining constructor checks.

Also included: `JWTAccessTokenIssuer{S}` is parameterized on its signer, and `TokenService` and `TokenEndpointConfig` carry that parameter. Token-mint signing dispatch is therefore static. Construction and the public API are unchanged. Version bumped to 4.4.0.

## Validation

- Full suite passes on Julia 1.10 and Julia 1.12.
- Both `juliac --trim=safe` workloads pass with zero verifier errors and zero warnings.
- Both compiled trim executables run successfully.
- The typed-claims server workload passes 7/7 harness checks.
- A `FileStore{AccessTokenRecord{AppClaims}}` with `JSONCodec()` round-trips the nested claims as `AppClaims`.
- The default `Dict{String,Any}` path remains covered and unchanged.

Generated with [Claude Code](https://claude.com/claude-code).

Co-authored by Codex