### PR TITLE
Write typed JOSE headers and claims at mint time; accept a pre-built signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,22 @@ register_jwks_endpoint!(router, [public_jwk(token_issuer)])
 
 `JWTAccessTokenIssuer` signs tokens, and the optional `AccessTokenStore` captures issued tokens for introspection and revocation. Server stores use the `AbstractStores.jl` interface. The application can therefore choose process memory, files, Redis, SQL, or another conforming backend. Tokens inherit scopes, authorization details, audiences, confirmation (`cnf`) claims, and extra custom claims in a single call.
 
+A statically compiled service can build its signer before issuer construction:
+
+```julia
+signer = OAuth.rsa_signer_from_bytes(read("keys/token-signing.pem"))
+token_issuer = JWTAccessTokenIssuer(
+    issuer="https://id.example",
+    audience=["https://api.example"],
+    signer=signer,
+    alg=:RS256,
+    kid="token-key-1",
+)
+```
+
+Provide exactly one of `private_key` or `signer`. OAuth rejects an algorithm or
+EC curve that does not match the signer.
+
 ```julia
 token_store = InMemoryTokenStore()
 issued = issue_access_token(
@@ -418,7 +434,9 @@ same three stores as a named tuple.
 Access-token claims use `Dict{String,Any}` by default. A trim-compiled service,
 or a service that wants typed JSON persistence, can declare its exact claim
 shape. Field names match JWT claim names. Optional fields include `Nothing`;
-unknown claims are dropped.
+unknown custom claims are dropped. The shape must include each registered claim
+that token minting uses. OAuth raises an error instead of silently dropping a
+registered claim such as `exp`, `scope`, or `cnf`.
 
 ```julia
 Base.@kwdef struct AccessClaims

--- a/src/jwt_util.jl
+++ b/src/jwt_util.jl
@@ -88,6 +88,12 @@ const SUPPORTED_RSA_ALGS = Set([:RS256, :PS256])
 const SUPPORTED_EC_ALGS = Set([:ES256, :ES384])
 const SUPPORTED_OKP_ALGS = Set([:EDDSA])
 
+signer_supports_alg(::RSASigner, alg::Symbol) = alg in SUPPORTED_RSA_ALGS
+signer_supports_alg(signer::ECSigner, alg::Symbol) =
+    (signer.curve === :P256 && alg === :ES256) ||
+    (signer.curve === :P384 && alg === :ES384)
+signer_supports_alg(::EdDSASigner, alg::Symbol) = alg in SUPPORTED_OKP_ALGS
+
 # OAuth normalizes algorithm symbols to uppercase; JWTs speaks RFC 7518 names.
 jose_alg_name(alg::Symbol) = alg === :EDDSA ? "EdDSA" : String(alg)
 
@@ -520,11 +526,16 @@ joseheader_json(h::JOSEHeader) = JSON.json(h; omit_null=true)
 # application-declared claims struct (see `AuthorizationServerStores(...;
 # claims=...)`), whose JSON write is then fully typed.
 function build_jws_compact(header::JOSEHeader, payload, signer::JWTSigner, alg::Symbol)
-    return _build_jws(joseheader_json(JOSEHeader(header.typ, String(alg), header.kid)), payload, signer, alg)
+    return _build_jws(
+        joseheader_json(JOSEHeader(header.typ, jose_alg_name(alg), header.kid)),
+        payload,
+        signer,
+        alg,
+    )
 end
 
 function build_jws_compact(header::Dict{String,Any}, payload, signer::JWTSigner, alg::Symbol)
-    header["alg"] = String(alg)
+    header["alg"] = jose_alg_name(alg)
     return _build_jws(JSON.json(header), payload, signer, alg)
 end
 
@@ -713,11 +724,14 @@ function _evp_bn_param(key::JWTs.OpenSSLKey, name::String)
     )
     JWTs.require_openssl_ok(ok, "EVP_PKEY_get_bn_param($name)")
     bn = bn_ref[]
+    JWTs.require_openssl_nonnull(bn, "EVP_PKEY_get_bn_param($name)")
     try
         nbytes = Int(ccall((:BN_num_bits, LIBCRYPTO), Cint, (Ptr{Cvoid},), bn) + 7) ÷ 8
+        nbytes > 0 || error("EVP_PKEY_get_bn_param($name) returned an empty integer")
         out = Vector{UInt8}(undef, nbytes)
         written = GC.@preserve out ccall((:BN_bn2bin, LIBCRYPTO), Cint, (Ptr{Cvoid}, Ptr{UInt8}), bn, pointer(out))
-        resize!(out, Int(written))
+        Int(written) == nbytes || error(
+            "BN_bn2bin($name) wrote $(Int(written)) bytes; expected $nbytes")
         return out
     finally
         JWTs.free_bn!(bn)

--- a/src/jwt_util.jl
+++ b/src/jwt_util.jl
@@ -500,9 +500,35 @@ const JWK_PRIVATE_MEMBERS = ("d", "p", "q", "dp", "dq", "qi", "oth", "k")
 jwk_has_private_material(jwk::Dict{String,String}) = any(member -> haskey(jwk, member), JWK_PRIVATE_MEMBERS)
 jwk_has_private_material(jwk::AbstractDict) = any(member -> haskey(jwk, member), JWK_PRIVATE_MEMBERS)
 
-function build_jws_compact(header::Dict{String,Any}, payload::Dict{String,Any}, signer::JWTSigner, alg::Symbol)
+"""
+    JOSEHeader(; typ="JWT", alg, kid=nothing)
+
+The JOSE header of a signed token. A fixed shape (RFC 7515 §4.1: `typ`, `alg`,
+`kid`), so it serializes through a typed JSON write; `kid` is omitted when
+absent.
+"""
+Base.@kwdef struct JOSEHeader
+    typ::String = "JWT"
+    alg::String = ""
+    kid::Union{Nothing,String} = nothing
+end
+
+joseheader_json(h::JOSEHeader) = JSON.json(h; omit_null=true)
+
+# `header` is a `JOSEHeader` (typed write) or a `Dict{String,Any}` for callers
+# that need extra members; `payload` is likewise the open claim set or an
+# application-declared claims struct (see `AuthorizationServerStores(...;
+# claims=...)`), whose JSON write is then fully typed.
+function build_jws_compact(header::JOSEHeader, payload, signer::JWTSigner, alg::Symbol)
+    return _build_jws(joseheader_json(JOSEHeader(header.typ, String(alg), header.kid)), payload, signer, alg)
+end
+
+function build_jws_compact(header::Dict{String,Any}, payload, signer::JWTSigner, alg::Symbol)
     header["alg"] = String(alg)
-    header_json = JSON.json(header)
+    return _build_jws(JSON.json(header), payload, signer, alg)
+end
+
+function _build_jws(header_json::String, payload, signer::JWTSigner, alg::Symbol)
     payload_json = JSON.json(payload)
     encoded_header = base64urlencode(header_json)
     encoded_payload = base64urlencode(payload_json)
@@ -662,6 +688,40 @@ function unwrap_pkcs8_private_key(bytes::Vector{UInt8})
     key_len, consumed = read_der_length(bytes, idx)
     idx += consumed
     return copy(bytes[idx:idx + key_len - 1])
+end
+
+"""
+    rsa_public_components(signer::RSASigner) -> (modulus, exponent)
+
+Big-endian modulus and public exponent read from the loaded key itself, so a
+JWK can be derived from a signer built without the PEM bytes at hand.
+"""
+function rsa_public_components(signer::RSASigner)
+    key = signer.key
+    n = _evp_bn_param(key, "n")
+    e = _evp_bn_param(key, "e")
+    return n, e
+end
+
+function _evp_bn_param(key::JWTs.OpenSSLKey, name::String)
+    bn_ref = Ref{Ptr{Cvoid}}(C_NULL)
+    ok = GC.@preserve key ccall(
+        (:EVP_PKEY_get_bn_param, LIBCRYPTO),
+        Cint,
+        (Ptr{Cvoid}, Cstring, Ref{Ptr{Cvoid}}),
+        key.ptr, name, bn_ref,
+    )
+    JWTs.require_openssl_ok(ok, "EVP_PKEY_get_bn_param($name)")
+    bn = bn_ref[]
+    try
+        nbytes = Int(ccall((:BN_num_bits, LIBCRYPTO), Cint, (Ptr{Cvoid},), bn) + 7) ÷ 8
+        out = Vector{UInt8}(undef, nbytes)
+        written = GC.@preserve out ccall((:BN_bn2bin, LIBCRYPTO), Cint, (Ptr{Cvoid}, Ptr{UInt8}), bn, pointer(out))
+        resize!(out, Int(written))
+        return out
+    finally
+        JWTs.free_bn!(bn)
+    end
 end
 
 function rsa_public_components_from_private_bytes(raw)

--- a/src/server.jl
+++ b/src/server.jl
@@ -427,9 +427,17 @@ end
 Loads the provided private key, deduces the right signer type, derives the
 public JWK (unless you supply one), and stores other helpful metadata.
 """
-function JWTAccessTokenIssuer(; issuer, audience, private_key, alg::Union{Symbol,AbstractString}=:RS256, kid=nothing, expires_in::Integer=3600, public_jwk=nothing)
+function JWTAccessTokenIssuer(; issuer, audience, private_key=nothing, signer::Union{Nothing,JWTSigner}=nothing, alg::Union{Symbol,AbstractString}=:RS256, kid=nothing, expires_in::Integer=3600, public_jwk=nothing)
     alg_symbol = Symbol(uppercase(String(alg)))
-    signer = if alg_symbol in SUPPORTED_RSA_ALGS
+    (private_key === nothing) == (signer === nothing) &&
+        throw(ArgumentError("JWTAccessTokenIssuer needs exactly one of private_key or signer"))
+    # A caller may pass a pre-built signer (`rsa_signer_from_bytes(pem)`, ...);
+    # the issuer's type is then concrete at the call site, where selecting the
+    # signer from the runtime `alg` would make it a union of the three signer
+    # types — the shape a statically compiled (juliac --trim) server needs.
+    signer = if signer !== nothing
+        signer
+    elseif alg_symbol in SUPPORTED_RSA_ALGS
         rsa_signer_from_bytes(private_key)
     elseif alg_symbol in SUPPORTED_EC_ALGS
         curve = alg_symbol == :ES256 ? :P256 : :P384
@@ -602,9 +610,12 @@ function issue_access_token(issuer::JWTAccessTokenIssuer; subject=nothing, clien
         value = get(cnf_claim, "jkt", nothing)
         cnf_thumbprint = value isa AbstractString ? String(value) : nothing
     end
-    header = Dict{String,Any}("typ" => "JWT")
-    issuer.kid !== nothing && (header["kid"] = issuer.kid)
-    token = build_jws_compact(header, claims, issuer.signer, issuer.alg)
+    header = JOSEHeader(; alg=String(issuer.alg), kid=issuer.kid)
+    # Sign the claims in the store's declared shape when there is one, so the
+    # JSON written into the token is a typed struct write rather than a
+    # Dict{String,Any} walk (the same shape the record persists).
+    signed_claims = store === nothing ? claims : storedclaims(claimstype(store), claims)
+    token = build_jws_compact(header, signed_claims, issuer.signer, issuer.alg)
     issued = IssuedAccessToken(token, claims, normalize_string_vector(scope), now, expires_at, client_id === nothing ? nothing : String(client_id), subject === nothing ? nothing : String(subject), cnf_thumbprint)
     store === nothing || store_access_token!(store, issued; now)
     return issued
@@ -626,7 +637,8 @@ public_jwk(issuer::JWTAccessTokenIssuer) = ensure_public_jwk!(issuer)
 token_alg_string(alg::Symbol) = alg == :EDDSA ? "EdDSA" : String(alg)
 
 function derive_signing_jwk(private_key, signer::RSASigner, alg::Symbol, kid::Union{String,Nothing})
-    modulus, exponent = rsa_public_components_from_private_bytes(private_key)
+    # from the key handle, so a pre-built signer (no PEM at hand) works too
+    modulus, exponent = rsa_public_components(signer)
     jwk = Dict(
         "kty" => "RSA",
         "n" => base64urlencode(modulus),

--- a/src/server.jl
+++ b/src/server.jl
@@ -422,10 +422,12 @@ mutable struct JWTAccessTokenIssuer{S<:JWTSigner}
 end
 
 """
-    JWTAccessTokenIssuer(; issuer, audience, private_key, alg=:RS256, kid=nothing, expires_in=3600, public_jwk=nothing)
+    JWTAccessTokenIssuer(; issuer, audience, private_key=nothing, signer=nothing,
+                         alg=:RS256, kid=nothing, expires_in=3600, public_jwk=nothing)
 
-Loads the provided private key, deduces the right signer type, derives the
-public JWK (unless you supply one), and stores other helpful metadata.
+Provide exactly one of `private_key` or a pre-built `signer`. The constructor
+checks that the signer, algorithm, and EC curve agree. It derives the public JWK
+unless you supply one, and stores other helpful metadata.
 """
 function JWTAccessTokenIssuer(; issuer, audience, private_key=nothing, signer::Union{Nothing,JWTSigner}=nothing, alg::Union{Symbol,AbstractString}=:RS256, kid=nothing, expires_in::Integer=3600, public_jwk=nothing)
     alg_symbol = Symbol(uppercase(String(alg)))
@@ -447,6 +449,8 @@ function JWTAccessTokenIssuer(; issuer, audience, private_key=nothing, signer::U
     else
         throw(ArgumentError("Unsupported signing alg $(alg_symbol)"))
     end
+    signer_supports_alg(signer, alg_symbol) || throw(ArgumentError(
+        "$(typeof(signer)) cannot sign with $(token_alg_string(alg_symbol))"))
     aud = normalize_string_vector(audience)
     kid_value = maybe_string(kid)
     jwk_dict = public_jwk === nothing ? derive_signing_jwk(private_key, signer, alg_symbol, kid_value) : normalize_metadata_dict(public_jwk)
@@ -511,6 +515,34 @@ storedclaims(::Type{Dict{String,Any}}, claims::Dict{String,Any}) = claims
         push!(values, :(get(claims, $key, nothing)::$field_type))
     end
     return :($C($(values...)))
+end
+
+const REGISTERED_ACCESS_TOKEN_CLAIMS = (
+    "iss",
+    "sub",
+    "aud",
+    "exp",
+    "iat",
+    "jti",
+    "client_id",
+    "scope",
+    "authorization_details",
+    "cnf",
+)
+
+validate_mint_claim_shape(::Type{Dict{String,Any}}, ::Dict{String,Any}) = nothing
+@generated function validate_mint_claim_shape(::Type{C}, claims::Dict{String,Any}) where {C}
+    if !(C isa DataType && isconcretetype(C) && isstructtype(C))
+        return :(throw(ArgumentError("access-token claims type $C must be a concrete struct")))
+    end
+    fields = Set(String.(fieldnames(C)))
+    checks = Any[]
+    for claim in REGISTERED_ACCESS_TOKEN_CLAIMS
+        claim in fields && continue
+        message = "access-token claims type $C has no field :$claim; minting would drop the $claim claim"
+        push!(checks, :(haskey(claims, $claim) && throw(ArgumentError($message))))
+    end
+    return Expr(:block, checks..., :(return nothing))
 end
 
 # Read one claim from a stored claims value: a dict lookup, or a field of a
@@ -579,12 +611,14 @@ to embed DPoP confirmation claims.
 """
 function issue_access_token(issuer::JWTAccessTokenIssuer; subject=nothing, client_id=nothing, scope=String[], authorization_details=nothing, extra_claims=Dict{String,Any}(), audience=nothing, now::DateTime=Dates.now(UTC), store::Union{Nothing,AccessTokenStore}=nothing, confirmation=nothing, confirmation_jkt=nothing)
     expires_at = now + Dates.Second(issuer.expires_in)
-    claims = Dict{String,Any}(
-        "iss" => issuer.issuer,
-        "aud" => token_audience(issuer, audience),
-        "exp" => datetime_to_unix(expires_at),
-        "iat" => datetime_to_unix(now),
-    )
+    # Build the heterogeneous dictionary one entry at a time. The vararg Pair
+    # constructor iterates through `Pair` values whose second field is `Any`,
+    # which leaves a dynamic `setindex!` call in trim-compiled applications.
+    claims = Dict{String,Any}()
+    claims["iss"] = issuer.issuer
+    claims["aud"] = token_audience(issuer, audience)
+    claims["exp"] = datetime_to_unix(expires_at)
+    claims["iat"] = datetime_to_unix(now)
     subject !== nothing && (claims["sub"] = String(subject))
     client_id !== nothing && (claims["client_id"] = String(client_id))
     !isempty(scope) && (claims["scope"] = join(String.(scope), ' '))
@@ -610,11 +644,17 @@ function issue_access_token(issuer::JWTAccessTokenIssuer; subject=nothing, clien
         value = get(cnf_claim, "jkt", nothing)
         cnf_thumbprint = value isa AbstractString ? String(value) : nothing
     end
-    header = JOSEHeader(; alg=String(issuer.alg), kid=issuer.kid)
+    header = JOSEHeader(; alg=jose_alg_name(issuer.alg), kid=issuer.kid)
     # Sign the claims in the store's declared shape when there is one, so the
     # JSON written into the token is a typed struct write rather than a
     # Dict{String,Any} walk (the same shape the record persists).
-    signed_claims = store === nothing ? claims : storedclaims(claimstype(store), claims)
+    signed_claims = if store === nothing
+        claims
+    else
+        C = claimstype(store)
+        validate_mint_claim_shape(C, claims)
+        storedclaims(C, claims)
+    end
     token = build_jws_compact(header, signed_claims, issuer.signer, issuer.alg)
     issued = IssuedAccessToken(token, claims, normalize_string_vector(scope), now, expires_at, client_id === nothing ? nothing : String(client_id), subject === nothing ? nothing : String(subject), cnf_thumbprint)
     store === nothing || store_access_token!(store, issued; now)

--- a/test/oauth_trim_server.jl
+++ b/test/oauth_trim_server.jl
@@ -93,6 +93,33 @@ function _trim_typed_claims_store()::Nothing
     )
     _trim_server_assert(OAuth.claimget(claims, "unknown") === nothing,
                         "unknown typed claim lookup")
+
+    signer = OAuth.rsa_signer_from_bytes(TRIM_PRIVATE_KEY_DER)
+    issuer = OAuth.JWTAccessTokenIssuer(
+        issuer="https://issuer.example",
+        audience=["https://api.example"],
+        signer=signer,
+        alg=:RS256,
+        kid="trim-key",
+        expires_in=600,
+    )
+    minted = OAuth.issue_access_token(
+        issuer;
+        subject="user-42",
+        client_id="soleil",
+        scope=["solar:read", "solar:write"],
+        extra_claims=Dict{String,Any}("tenant" => "acme"),
+        now,
+        store=stores.access_tokens,
+    )
+    _trim_server_assert(occursin(".", minted.token), "signed compact token")
+    minted_record = OAuth.lookup_access_token(stores.access_tokens, minted.token)
+    minted_record isa OAuth.AccessTokenRecord{TrimClaims} ||
+        error("typed minted access token record")
+    _trim_server_assert(minted_record.claims.tenant == "acme", "typed minted claim")
+    jwk = OAuth.public_jwk(issuer)
+    _trim_server_assert(!isempty(jwk["n"]::String), "derived RSA modulus")
+    _trim_server_assert(!isempty(jwk["e"]::String), "derived RSA exponent")
     return nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1623,6 +1623,13 @@ end
         extra_claims = Dict{String,Any}("tenant" => "acme", "ignored_by_struct" => 1),
         store = stores.access_tokens,
     )
+    header, payload, _, _ = OAuth.decode_compact_jwt(issued.token)
+    @test header["typ"] == "JWT"
+    @test header["alg"] == "RS256"
+    @test !haskey(header, "kid")
+    @test payload["sub"] == "user-9"
+    @test payload["tenant"] == "acme"
+    @test !haskey(payload, "ignored_by_struct")
     record = lookup_access_token(stores.access_tokens, issued.token)
     @test record isa AccessTokenRecord{AppClaims}
     @test record.claims.sub == "user-9"
@@ -1654,6 +1661,44 @@ end
     @test OAuth.claimstype(default_store) === Dict{String,Any}
     issued2 = issue_access_token(issuer; subject = "user-10", store = default_store)
     @test lookup_access_token(default_store, issued2.token).claims isa Dict{String,Any}
+
+    @test_throws ArgumentError issue_access_token(
+        issuer;
+        subject = "user-11",
+        confirmation_jkt = "thumbprint",
+        store = stores.access_tokens,
+    )
+end
+
+@testset "pre-built access-token signer" begin
+    rsa_pem = fixture_string("rsa_private.pem")
+    signer = OAuth.rsa_signer_from_bytes(rsa_pem)
+    issuer = JWTAccessTokenIssuer(
+        issuer = "https://id.example.com",
+        audience = ["https://api.example.com"],
+        signer = signer,
+        alg = :RS256,
+        kid = "prebuilt-rsa",
+    )
+    jwk = public_jwk(issuer)
+    modulus, exponent = OAuth.rsa_public_components_from_private_bytes(rsa_pem)
+    @test jwk["n"] == OAuth.base64urlencode(modulus)
+    @test jwk["e"] == OAuth.base64urlencode(exponent)
+
+    issued = issue_access_token(issuer; subject = "prebuilt-user")
+    validator = TokenValidationConfig(
+        issuer = "https://id.example.com",
+        audience = ["https://api.example.com"],
+        jwks = Dict("keys" => [jwk]),
+    )
+    @test validate_jwt_access_token(issued.token, validator).subject == "prebuilt-user"
+
+    common = (; issuer="https://id.example.com", audience=["https://api.example.com"])
+    @test_throws ArgumentError JWTAccessTokenIssuer(; common...)
+    @test_throws ArgumentError JWTAccessTokenIssuer(; common..., private_key=rsa_pem, signer=signer)
+    @test_throws ArgumentError JWTAccessTokenIssuer(; common..., signer=signer, alg=:ES256)
+    ec_signer = OAuth.ecc_signer_from_bytes(fixture_string("ec_private.pem"), :P256)
+    @test_throws ArgumentError JWTAccessTokenIssuer(; common..., signer=ec_signer, alg=:ES384)
 end
 
 @testset "Server helpers" begin
@@ -1881,6 +1926,8 @@ end
         kid = "ed-kid",
     )
     ed_token = issue_access_token(ed_issuer; subject = "ed-user")
+    ed_header, _, _, _ = OAuth.decode_compact_jwt(ed_token.token)
+    @test ed_header["alg"] == "EdDSA"
     ed_jwk = public_jwk(ed_issuer)
     @test ed_jwk["kty"] == "OKP"
     ed_validator = TokenValidationConfig(


### PR DESCRIPTION
Follow-up to #46, from the JuliaCon 2026 workshop trim work: with the claims *payload* typed, the remaining OAuth-owned `juliac --trim=safe` verify errors were all at token-mint time — the JOSE header dict, the payload dict write, and the issuer's runtime signer selection. Three changes, none affecting the default dynamic path:

**Typed JOSE header.** A JOSE header is a fixed shape (RFC 7515 §4.1), so `issue_access_token` now builds a `JOSEHeader` struct (`typ`/`alg`/`kid`, `kid` omitted when absent) whose JSON write is fully typed. `build_jws_compact` still accepts a plain `Dict{String,Any}` for callers that need extra members; both routes share one `_build_jws`.

**Typed payload write.** When the token store declares a claims type (`AuthorizationServerStores(backend; claims=MyClaims)`), the signed payload is written as that struct too (`storedclaims` at mint) — the write-side twin of the typed record reads that #46 added. Stores without a declared type sign the dict exactly as before.

**Pre-built signer.** `JWTAccessTokenIssuer(; signer=rsa_signer_from_bytes(pem), ...)` accepts a pre-built signer as an alternative to `private_key` (exactly one required), giving the issuer a concrete type at the call site where selecting from the runtime `alg` would make it a three-way union. The RSA public JWK is now derived from the key handle itself (`EVP_PKEY_get_bn_param`), matching how the EC/EdDSA derivations already work, so no PEM bytes are needed.

Full suite (including the trim harness) passes on 1.12.6. In the workshop app these clear the last four `JSON.lower` verify errors at mint time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up

- Exercise typed token minting in the trim workload.
- Validate signer type, JOSE algorithm, and EC curve agreement.
- Derive RSA JWK values defensively and emit canonical `EdDSA`.
- Reject typed claim shapes that would drop a registered claim used during minting.

Validation: Julia 1.10 and current suites pass. The mint workload builds and runs with zero verifier errors.

Co-authored by Codex